### PR TITLE
Fix to ignore plugin dev-dependencies on install

### DIFF
--- a/lib/package-manager.coffee
+++ b/lib/package-manager.coffee
@@ -309,7 +309,7 @@ class PackageManager
     nameWithVersion = if version? then "#{name}@#{version}" else name
 
     @unload(name)
-    args = ['install', nameWithVersion, '--json']
+    args = ['install', nameWithVersion, '--production', '--json']
 
     errorMessage = "Installing \u201C#{nameWithVersion}\u201D failed."
     onError = (error) =>


### PR DESCRIPTION
:racehorse:  Only added the `--production` flag to `apm install`

Nylas N1 uses the same install script as Atom and on N1, installing packages wth a large number of dev-dependencies fails to install. From my knowledge, there is no need to install dev-dependencies on a redistributed package, so this should help speed up the install process and avoid errors such as seen in Nylas N1: https://github.com/nylas/N1/issues/2723#issuecomment-240983812

The same change was merged to the master branch of Nylas and released this morning: https://github.com/nylas/N1/pull/2741